### PR TITLE
Testing updates

### DIFF
--- a/.github/actions/integration_tests/action.yml
+++ b/.github/actions/integration_tests/action.yml
@@ -22,17 +22,6 @@ runs:
         mv $TFENV_DL_TMP/tfenv-2989f1a5560e313f70f7711be592ddb68418862b ~/.tfenv
         echo "$HOME/.tfenv/bin" >> $GITHUB_PATH
       shell: bash
-    # terraform-credentials-env can be dropped when moving to TF v1.2+
-    - run: echo "Installing terraform-credentials-env"
-      shell: bash
-    - name: Install terraform-credentials-env
-      run: |
-        mkdir -p ~/.terraform.d/plugins
-        TFCREDENV_DL_TMP=$(mktemp -d)
-        curl -Lo $TFCREDENV_DL_TMP/terraform-credentials-env_1.0.0_linux_amd64.zip https://github.com/apparentlymart/terraform-credentials-env/releases/download/v1.0.0/terraform-credentials-env_1.0.0_linux_amd64.zip
-        unzip $TFCREDENV_DL_TMP/terraform-credentials-env_1.0.0_linux_amd64.zip -d ~/.terraform.d/plugins
-        echo 'credentials_helper "env" {}' >> ~/.terraformrc
-      shell: bash
     - run: echo "Deploying and running tests"
       shell: bash
     - name: Deploy and run tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,8 +24,6 @@ jobs:
       AWS_PERMISSIONS_BOUNDARY: ${{ secrets.AWS_PERMISSIONS_BOUNDARY }}
       TEST_CONSUL_ENT_LICENSE: ${{ secrets.TEST_CONSUL_ENT_LICENSE }}
       TF_TOKEN_app_terraform_io: ${{ secrets.TF_TOKEN_app_terraform_io }}
-      # Drop registry_terraform_io env var when switching to tf v1.2+
-      TF_TOKEN_registry_terraform_io: ${{ secrets.TF_TOKEN_app_terraform_io }}
     steps:
     - name: Branch based PR checkout
       uses: actions/checkout@v2
@@ -55,8 +53,6 @@ jobs:
       AWS_PERMISSIONS_BOUNDARY: ${{ secrets.AWS_PERMISSIONS_BOUNDARY }}
       TEST_CONSUL_ENT_LICENSE: ${{ secrets.TEST_CONSUL_ENT_LICENSE }}
       TF_TOKEN_app_terraform_io: ${{ secrets.TF_TOKEN_app_terraform_io }}
-      # Drop registry_terraform_io env var when switching to tf v1.2+
-      TF_TOKEN_registry_terraform_io: ${{ secrets.TF_TOKEN_app_terraform_io }}
     steps:
     # Check out merge commit
     - name: Fork based /ok-to-test checkout

--- a/examples/prereqs_quickstart/outputs.tf
+++ b/examples/prereqs_quickstart/outputs.tf
@@ -40,3 +40,7 @@ output "eks_2_kube_api_endpoint" {
 output "secrets_manager_name" {
   value = module.secrets_manager.secrets_manager_name
 }
+
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}

--- a/test/deployment_test.go
+++ b/test/deployment_test.go
@@ -96,7 +96,11 @@ func TestClusterDeployment(t *testing.T) {
 	}
 	createTfcWorkspace(t, tfcOrg, tfcToken, prereqsWorkspaceName)
 	os.Setenv("TF_WORKSPACE", prereqsWorkspaceName)
-	terraform.InitAndApplyAndIdempotent(t, prereqsTerraformOptions)
+	terraform.Init(t, prereqsTerraformOptions)
+	if os.Getenv("GITHUB_ACTIONS") == "" {
+		writeWorkspaceNameToTfDir(prereqsModulePath, prereqsWorkspaceName)
+	}
+	terraform.ApplyAndIdempotent(t, prereqsTerraformOptions)
 	// Gather prereqs outputs
 	primaryClusterName := terraform.Output(t, prereqsTerraformOptions, "primary_cluster_name")
 	secondaryClusterName := terraform.Output(t, prereqsTerraformOptions, "secondary_cluster_name")
@@ -115,7 +119,11 @@ func TestClusterDeployment(t *testing.T) {
 	}
 	createTfcWorkspace(t, tfcOrg, tfcToken, primaryWorkspaceName)
 	os.Setenv("TF_WORKSPACE", primaryWorkspaceName)
-	terraform.InitAndApplyAndIdempotent(t, primaryTerraformOptions)
+	terraform.Init(t, primaryTerraformOptions)
+	if os.Getenv("GITHUB_ACTIONS") == "" {
+		writeWorkspaceNameToTfDir(primaryModulePath, primaryWorkspaceName)
+	}
+	terraform.ApplyAndIdempotent(t, primaryTerraformOptions)
 
 	// Run secondary module, and setup its destruction during CI
 	// (no-CI destruction is conditionally configured after tests below)
@@ -130,7 +138,11 @@ func TestClusterDeployment(t *testing.T) {
 	}
 	createTfcWorkspace(t, tfcOrg, tfcToken, secondaryWorkspaceName)
 	os.Setenv("TF_WORKSPACE", secondaryWorkspaceName)
-	terraform.InitAndApplyAndIdempotent(t, secondaryTerraformOptions)
+	terraform.Init(t, secondaryTerraformOptions)
+	if os.Getenv("GITHUB_ACTIONS") == "" {
+		writeWorkspaceNameToTfDir(secondaryModulePath, secondaryWorkspaceName)
+	}
+	terraform.ApplyAndIdempotent(t, secondaryTerraformOptions)
 
 	// Run app primary module, and setup its destruction during CI
 	// (no-CI destruction is conditionally configured after tests below)
@@ -145,7 +157,11 @@ func TestClusterDeployment(t *testing.T) {
 	}
 	createTfcWorkspace(t, tfcOrg, tfcToken, appPrimaryWorkspaceName)
 	os.Setenv("TF_WORKSPACE", appPrimaryWorkspaceName)
-	terraform.InitAndApplyAndIdempotent(t, appPrimaryTerraformOptions)
+	terraform.Init(t, appPrimaryTerraformOptions)
+	if os.Getenv("GITHUB_ACTIONS") == "" {
+		writeWorkspaceNameToTfDir(appPrimaryModulePath, appPrimaryWorkspaceName)
+	}
+	terraform.ApplyAndIdempotent(t, appPrimaryTerraformOptions)
 
 	// Run app secondary module, and setup its destruction during CI
 	// (no-CI destruction is conditionally configured after tests below)
@@ -160,7 +176,11 @@ func TestClusterDeployment(t *testing.T) {
 	}
 	createTfcWorkspace(t, tfcOrg, tfcToken, appSecondaryWorkspaceName)
 	os.Setenv("TF_WORKSPACE", appSecondaryWorkspaceName)
-	terraform.InitAndApplyAndIdempotent(t, appSecondaryTerraformOptions)
+	terraform.Init(t, appSecondaryTerraformOptions)
+	if os.Getenv("GITHUB_ACTIONS") == "" {
+		writeWorkspaceNameToTfDir(appSecondaryModulePath, appSecondaryWorkspaceName)
+	}
+	terraform.ApplyAndIdempotent(t, appSecondaryTerraformOptions)
 
 	// Run validation module, and setup its destruction during CI
 	// (no-CI destruction is conditionally configured after tests below)
@@ -175,7 +195,11 @@ func TestClusterDeployment(t *testing.T) {
 	}
 	createTfcWorkspace(t, tfcOrg, tfcToken, validationWorkspaceName)
 	os.Setenv("TF_WORKSPACE", validationWorkspaceName)
-	terraform.InitAndApply(t, validationTerraformOptions)
+	terraform.Init(t, validationTerraformOptions)
+	if os.Getenv("GITHUB_ACTIONS") == "" {
+		writeWorkspaceNameToTfDir(validationModulePath, validationWorkspaceName)
+	}
+	terraform.Apply(t, validationTerraformOptions)
 	// Gather validation outputs
 	consulWanMembers := terraform.Output(t, validationTerraformOptions, "consul_wan_members")
 	nodeGroupRootBlockDeviceVolumeType := terraform.Output(t, validationTerraformOptions, "node_group_root_block_device_volume_type")

--- a/test/utils.go
+++ b/test/utils.go
@@ -205,3 +205,10 @@ func removeAutoTfvars(t *testing.T, path string) {
 		}
 	}
 }
+
+// Persist Terraform Workspace name so users can run diagnostic
+// Terraform commands without setting the TF_WORKSPACE env var or
+// running "terraform workspace select" first
+func writeWorkspaceNameToTfDir(modulePath string, workspaceName string) {
+	ioutil.WriteFile(filepath.Join(modulePath, ".terraform", "environment"), []byte(workspaceName), 0644)
+}


### PR DESCRIPTION
A few testing updates:

* Most notably, there's an [AWS cleanup bug](https://github.com/hashicorp/terraform-provider-aws/issues/20925) that can sometimes cause the terraform apply/destroy cycle to fail (this isn't specific to the automated setup or running on CI). Now the tests will watch for those lingering ENIs & Security Groups and purge them during the destroy process.
* When running locally (not in CI), the test script will now ensure that the Terraform workspace name is persisted to disk. This should be useful in debugging sessions -- now one can just switch to the relevant module directory and run terraform commands without selecting the workspace again.
* Finally, dropped legacy terraform-credentials-env plugin use now that tests only use TF 1.2+